### PR TITLE
Fix "Blog" footer link

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -69,7 +69,7 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>More</h5>
-            <a href={this.props.config.baseUrl + 'blog'}>Blog</a>
+            <a href="https://medium.com/webmr">Blog</a>
             <a href="https://github.com/webmixedreality/exokit">GitHub</a>
             <a
               className="github-button"


### PR DESCRIPTION
- "Blog" footer link points to medium.com/webmr

**Note:**
Tested locally :heavy_check_mark: 