### PR TITLE
Fix typo on index.js

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -148,7 +148,7 @@ const LearnHow = props => (
   <Block>
     {[
       {
-        content: 'Learn how to get started developing with Exokit with out comprehensive documentation.',
+        content: 'Learn how to get started developing with Exokit with our comprehensive documentation.',
         image: imgUrl('user-graduate.svg'),
         imageAlign: 'right',
         className: 'featureIcon',


### PR DESCRIPTION
Fix typo `out` to `our` documentation.