### PR TITLE
Add Home Link and Update Blog Links

### DIFF
--- a/docs/Support.md
+++ b/docs/Support.md
@@ -8,7 +8,7 @@ sidebar_label: Resources and Support
 Explore the various projects on [GitHub.](https://github.com/webmixedreality)
 
 # Blog
-Check out our [blog](https://medium.com/webmr) for weekly updates on all we are doing as well as any big announcements or changes.
+Check out our [blog](https://webmr.io/blog) for weekly updates on all we are doing as well as any big announcements or changes.
 
 # Support
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,7 +8,7 @@ sidebar_label: Community Links
 The main GitHub repository is [here](https://github.com/webmixedreality/exokit).
 
 # Blog
-We post announcements and updates to our [blog](https://medium.com/webmr).
+We post announcements and updates to our [blog](https://webmr.io/blog).
 
 # Support
 

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -66,10 +66,11 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
+    {href: 'https://webmr.io/', label: 'Home' },
     {doc: 'exokitEngine', label: 'Docs'},
     {doc: 'SDKLanding', label: 'SDK'},
     {page: 'help', label: 'Help'},
-    {href: 'https://medium.com/webmr', label: 'Blog' },
+    {href: 'https://webmr.io/blog', label: 'Blog' },
     { search: true }
   ],
 


### PR DESCRIPTION
This PR includes: 

- Add "Home" link in header nav to point to the landing page `https://webmr.io/`
- All "Blog" links point to `https://webmr.io/blog` - the blog posts will be posted to _both_ medium and `webmr.io/blog` , but it is best to internally point to `webmr.io/blog` to keep people from having to go to a 3rd party site.